### PR TITLE
Added support for Netbox 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.5 (2023-09-08)
+
+* Fix for NetBox 3.6.0
+
 ## 0.1.4 (2023-08-18)
 
 * Fix for NetBox 3.5.8

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The features the plugin provides should be listed here.
 |----------------|----------------|
 |     3.5        |      0.1.0     |
 |     3.5.8      |      0.1.4     |
-
+|     3.6.0 >      |      0.1.5     |
 ## Installation
 
 For adding to a NetBox Docker setup see

--- a/netbox_napalm_plugin/__init__.py
+++ b/netbox_napalm_plugin/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Arthur Hanson"""
 __email__ = "ahanson@netboxlabs.com"
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 
 from extras.plugins import PluginConfig
@@ -22,7 +22,7 @@ class NapalmPlatformConfig(PluginConfig):
         'NAPALM_ARGS': {},
     }
     min_version = '3.5.0-dev'
-    max_version = '3.5.99'
+    max_version = '3.6.99'
 
 
 config = NapalmPlatformConfig

--- a/netbox_napalm_plugin/project-static/package.json
+++ b/netbox_napalm_plugin/project-static/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netbox_napalm_plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Napalm Plugin for NetBox",
   "main": "index.js",
   "author": "Arthur Hanson",

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ python =
     3.8: py38, format, lint, build
 
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.1.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
     packages=find_packages(include=['netbox_napalm_plugin', 'netbox_napalm_plugin.*']),
     test_suite='tests',
     url='https://github.com/netbox-community/netbox-napalm',
-    version='0.1.4',
+    version='0.1.5',
     zip_safe=False,
 )


### PR DESCRIPTION
This adds support for Netbox 3.6. I've tested it with 3.6.0 and 3.6.1.

In Netbox 3.6 Napalm config has been removed from the DCIM.Platform model.