### PR TITLE
Replaced underscores with hyphens in baseurl

### DIFF
--- a/netbox_napalm_plugin/__init__.py
+++ b/netbox_napalm_plugin/__init__.py
@@ -15,7 +15,7 @@ class NapalmPlatformConfig(PluginConfig):
     version = __version__
     author = __author__
     author_email = __email__
-    base_url = "netbox_napalm_plugin"
+    base_url = "netbox-napalm-plugin"
     required_settings = ['NAPALM_USERNAME', 'NAPALM_PASSWORD', ]
     default_settings = {
         'NAPALM_TIMEOUT': 30,


### PR DESCRIPTION
Replacing underscores with hypens in the base_url setting in order to follow Netbox plugin conventions and enable pynetbox compatibility.