### PR TITLE
Add Python 3.13 and allow Napalm 5 in project file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,12 @@ classifiers=[
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 
 requires-python = ">=3.10.0"
 dependencies = [
-    'napalm<5.0'
+    'napalm<6.0'
 ]
 
 [project.optional-dependencies]
@@ -46,7 +47,7 @@ Tracker = "https://github.com/netbox-community/netbox-napalm-plugin/issues"
 
 [tool.black]
 line-length = 120
-target_version = ['py310', 'py311', 'py312']
+target_version = ['py310', 'py311', 'py312', 'py313']
 
 [tool.setuptools.package-data]
 netbox_napalm_plugin = ["templates/**"]


### PR DESCRIPTION
It looks like this plugin works fine with Python 3.13, also Napalm 5 has no breaking changes listed that would affect this. Tested on our basic setup where Napalm 4 won't run because it's not compatible with Python 3.13.